### PR TITLE
downgrade flink-table v0.10.1  to v0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table</artifactId>
-			<version>${flink.version}</version>
+			<version>0.10.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
building an exercises is just not possible, cause there is no  flink-table of version 0.10.1