### PR TITLE
Attach Scala sources during package phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,14 @@
 							<goal>testCompile</goal>
 						</goals>
 					</execution>
+
+					<execution>
+						<id>scala-add-source</id>
+						<phase>package</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+					</execution>
 				</executions>
 				<configuration>
 					<jvmArgs>


### PR DESCRIPTION
This attaches the Scala sources to maven's source artifact (`flink-training-exercises-0.11.0-sources.jar`)