### PR TITLE
 Remove usage of deprecated ValueStateDescriptor constructor

### DIFF
--- a/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/state/TravelTimePrediction.java
+++ b/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/state/TravelTimePrediction.java
@@ -126,6 +126,9 @@ public class TravelTimePrediction {
 
 			// fetch operator state
 			TravelTimePredictionModel model = modelState.value();
+			if (model == null) {
+				model = new TravelTimePredictionModel();
+			}
 
 			TaxiRide ride = val.f1;
 			// compute distance and direction
@@ -156,9 +159,7 @@ public class TravelTimePrediction {
 							// state name
 							"regressionModel",
 							// type information of state
-							TypeInformation.of(new TypeHint<TravelTimePredictionModel>() {}),
-							// default value of state
-							new TravelTimePredictionModel());
+							TypeInformation.of(new TypeHint<TravelTimePredictionModel>() {}));
 			modelState = getRuntimeContext().getState(descriptor);
 		}
 	}

--- a/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/state/TravelTimePrediction.java
+++ b/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/state/TravelTimePrediction.java
@@ -159,7 +159,7 @@ public class TravelTimePrediction {
 							// state name
 							"regressionModel",
 							// type information of state
-							TypeInformation.of(new TypeHint<TravelTimePredictionModel>() {}));
+							TypeInformation.of(TravelTimePredictionModel.class));
 			modelState = getRuntimeContext().getState(descriptor);
 		}
 	}

--- a/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/state/TravelTimePrediction.java
+++ b/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/state/TravelTimePrediction.java
@@ -135,7 +135,7 @@ public class TravelTimePrediction {
 			double distance = GeoUtils.getEuclideanDistance(ride.startLon, ride.startLat, ride.endLon, ride.endLat);
 			int direction = GeoUtils.getDirectionAngle(ride.endLon, ride.endLat, ride.startLon, ride.startLat);
 
-			if(ride.isStart) {
+			if (ride.isStart) {
 				// we have a start event: Predict travel time
 				int predictedTime = model.predictTravelTime(direction, distance);
 				// emit prediction


### PR DESCRIPTION
This removes the usage of the deprecated ValueStateDescriptor constructor which accepts a 
default value. As proposed by the documentation, the default value is now manually managed:
```
[...]
 * @deprecated Use {@link #ValueStateDescriptor(String, TypeSerializer)} instead and manually
 * manage the default value by checking whether the contents of the state is {@code null}.
[...]
```