### PR TITLE
Fix session gap value in Javadoc

### DIFF
--- a/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/datatypes/GapSegment.java
+++ b/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/datatypes/GapSegment.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 /**
- * A GapSegment is punctuated by an interval of more than 5 seconds without data.
+ * A GapSegment is punctuated by an interval of more than 15 seconds without data.
  */
 public class GapSegment extends Segment {
 	public GapSegment(Iterable<ConnectedCarEvent> events) {

--- a/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/windows/DrivingSessions.java
+++ b/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/windows/DrivingSessions.java
@@ -36,7 +36,7 @@ import org.apache.flink.util.Collector;
  * (http://training.data-artisans.com).
  * <p>
  * The task of the exercise is to divide the input stream of ConnectedCarEvents into
- * session windows, defined by a gap of 5 seconds. Each window should then be mapped onto
+ * session windows, defined by a gap of 15 seconds. Each window should then be mapped onto
  * a GapSegment object.
  * <p>
  * Parameters:


### PR DESCRIPTION
The exercise http://training.data-artisans.com/exercises/carSegments.html requires a session gap of 15s. This session window is created correctly but the Javadoc says 5s.