### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+  - openjdk8
+  - oraclejdk8
+
+script: mvn clean install


### PR DESCRIPTION
- There are no unit tests in this project yet but the build fails if there are checkstyle violations.
- `openjdk8` and `oraclejdk8` are used due to #16 