### PR TITLE
Fix generics in ProcessingTimeJoinExercise

### DIFF
--- a/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/process/ProcessingTimeJoinExercise.java
+++ b/src/main/java/com/dataartisans/flinktraining/exercises/datastream_java/process/ProcessingTimeJoinExercise.java
@@ -86,14 +86,14 @@ public class ProcessingTimeJoinExercise {
 
 		@Override
 		public void open(Configuration config) {
-			MapStateDescriptor tDescriptor = new MapStateDescriptor<Long, Trade>(
+			MapStateDescriptor<Long, Trade> tDescriptor = new MapStateDescriptor<>(
 					"tradeBuffer",
 					TypeInformation.of(Long.class),
 					TypeInformation.of(Trade.class)
 			);
 			tradeMap = getRuntimeContext().getMapState(tDescriptor);
 
-			ValueStateDescriptor cDescriptor = new ValueStateDescriptor<Customer>(
+			ValueStateDescriptor<Customer> cDescriptor = new ValueStateDescriptor<>(
 					"customer",
 					TypeInformation.of(Customer.class)
 			);


### PR DESCRIPTION
This gets rid of a warning due to unchecked assignments in `ProcessingTimeJoinExercise`.