### PR TITLE
Update dependencies to Flink 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	
 	<groupId>com.data-artisans</groupId>
 	<artifactId>flink-training-exercises</artifactId>
-	<version>2.4.3</version>
+	<version>2.5.0</version>
 	<packaging>jar</packaging>
 
 	<name>Apache Flink Training Exercises</name>
@@ -51,7 +51,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<slf4j.version>1.7.19</slf4j.version>
-		<flink.version>1.6.0</flink.version>
+		<flink.version>1.7.1</flink.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<junit.version>4.12</junit.version>
 	</properties>


### PR DESCRIPTION
Signed-off-by: EronWright <eronwright@gmail.com>

Update the dependencies to use Flink 1.7.1 (previously 1.6).   I'm not aware of any changes needed to the shading configuration, do tell if anything is known to have changed.